### PR TITLE
Make XenServer images smaller

### DIFF
--- a/internal/template.json
+++ b/internal/template.json
@@ -94,7 +94,7 @@
                 "sshpassword=password atexit=shell --- /install.img<enter>"
             ],
             "boot_wait": "3s",
-            "disk_size": 512000,
+            "disk_size": 102400,
             "format":"xva",
             "http_directory": "http",
  	    "http_port_min": 2375,


### PR DESCRIPTION
500GiB is too much, takes ages to build/export with packer (~48m for a build).
I think this got increased for the techfair, but we usually don't need images this big.